### PR TITLE
Updates to latest assemblyscript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,73 @@
 {
   "name": "@wapc/as-guest",
-  "version": "0.2.1",
-  "lockfileVersion": 1,
+  "version": "0.3.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@wapc/as-guest",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "assemblyscript": "^0.20.13"
+      }
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.20.13",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.20.13.tgz",
+      "integrity": "sha512-F4ACXdBdXCBnPEzRCl/ovFFPGmKXQPvWW4cM6U21eRezaCoREqxA0hjSUOYTz7txY3MJclyBfjwMSEJ5e9HKsw==",
+      "dev": true,
+      "dependencies": {
+        "binaryen": "108.0.0-nightly.20220528",
+        "long": "^5.2.0"
+      },
+      "bin": {
+        "asc": "bin/asc.js",
+        "asinit": "bin/asinit.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "108.0.0-nightly.20220528",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-108.0.0-nightly.20220528.tgz",
+      "integrity": "sha512-9biG357fx3NXmJNotIuY9agZBcCNHP7d1mgOGaTlPYVHZE7/61lt1IyHCXAL+W5jUOYgmFZ260PR4IbD19RKuA==",
+      "dev": true,
+      "bin": {
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "assemblyscript": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.17.1.tgz",
-      "integrity": "sha512-0cBGno+GYlY871s82WXhA5peRJxktGchJ7mdBDhf7mwoe4bPNuBrYYl2jRcXs8nQA/eQHNUiCJQ5dL61zQMXjw==",
+      "version": "0.20.13",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.20.13.tgz",
+      "integrity": "sha512-F4ACXdBdXCBnPEzRCl/ovFFPGmKXQPvWW4cM6U21eRezaCoREqxA0hjSUOYTz7txY3MJclyBfjwMSEJ5e9HKsw==",
       "dev": true,
       "requires": {
-        "binaryen": "98.0.0-nightly.20201027",
-        "long": "^4.0.0"
+        "binaryen": "108.0.0-nightly.20220528",
+        "long": "^5.2.0"
       }
     },
     "binaryen": {
-      "version": "98.0.0-nightly.20201027",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20201027.tgz",
-      "integrity": "sha512-00/IHlumty/5XzJsdaMudayXofJiDb3Ytqqdn7OJBM0L9SuVg0o0xu4l93NVf+hO6jkgXNE1t+LdB0gOdeLdjA==",
+      "version": "108.0.0-nightly.20220528",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-108.0.0-nightly.20220528.tgz",
+      "integrity": "sha512-9biG357fx3NXmJNotIuY9agZBcCNHP7d1mgOGaTlPYVHZE7/61lt1IyHCXAL+W5jUOYgmFZ260PR4IbD19RKuA==",
       "dev": true
     },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wapc/as-guest",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "types": "assembly/index.ts",
   "description": "waPC Guest Library for AssemblyScript",
   "repository": {
@@ -14,6 +14,6 @@
   },
   "homepage": "https://github.com/wapc/as-guest#readme",
   "devDependencies": {
-    "assemblyscript": "^0.17.1"
+    "assemblyscript": "^0.20.13"
   }
 }


### PR DESCRIPTION
In https://github.com/wapc/wapc-go/pull/32 I noticed a failure if I tried to use a more recent version of assemblyscript